### PR TITLE
feat: add public emit() method to EventManager

### DIFF
--- a/src/event-manager.ts
+++ b/src/event-manager.ts
@@ -216,6 +216,19 @@ export class EventManager {
     this._removeEventHandler(event, handler);
   }
 
+  /**
+   * Emit a custom event into the event pipeline.
+   * This allows external input sources (hand tracking, game controllers,
+   * voice commands, etc.) to inject events that flow through the standard
+   * EventRegistrar dispatch system.
+   *
+   * @param event - The event to emit. Must have a `type` field matching
+   *   a recognized event name (e.g., 'panmove', 'wheel', 'custom-event').
+   */
+  emit(event: MjolnirEventRaw): void {
+    this.manager?.emit(event.type, event as any);
+  }
+
   /*
    * Enable/disable recognizer for the given event
    */

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ export {
 // types
 export type {EventManagerOptions, RecognizerTuple} from './event-manager';
 export type {
+  MjolnirEventRaw,
   MjolnirEvent,
   MjolnirGestureEvent,
   MjolnirKeyEvent,


### PR DESCRIPTION
## Summary

Add a public `emit()` method to `EventManager` that allows external input sources to inject events into mjolnir's event pipeline.

### Motivation

mjolnir.js's built-in input classes (`WheelInput`, `MoveInput`, `KeyInput`, `ContextmenuInput`) inject events via the private `_onOtherEvent` callback, which calls `this.manager.emit(event.type, event)`. However, there is no public API for **external** code to emit events into the same pipeline.

This is needed for [thor.gl](https://github.com/NEW-HEAT/thor.gl) — a human body input device library (hand tracking, eye tracking, etc.) for deck.gl — but the use case is general: any custom input source (game controllers, WebXR devices, voice commands, accessibility tools, etc.) should be able to emit events that flow through mjolnir's standard `EventRegistrar` dispatch system.

Reference: https://github.com/NEW-HEAT/thor.gl/issues/1

### Changes

- **`src/event-manager.ts`**: Added a public `emit(event: MjolnirEventRaw)` method to `EventManager`. The implementation is a single line — it delegates to the internal Hammer manager's `emit()`, which is the exact same path used by the existing `_onOtherEvent` private callback. Placed after `off()` in the public API surface.

- **`src/index.ts`**: Exported the `MjolnirEventRaw` type from the package's public API, so consumers can properly type the events they pass to `emit()`.

### Backward Compatibility

This is a purely additive change:
- No existing APIs are modified
- No existing behavior is changed
- No breaking changes
- The new method is optional — existing consumers are unaffected

### Usage Example

```typescript
import { EventManager, MjolnirEventRaw } from 'mjolnir.js';

const eventManager = new EventManager(element, { ... });

// Register a handler as usual
eventManager.on('handmove', (event) => {
  console.log('Hand moved:', event);
});

// Emit a custom event from an external input source
const handEvent: MjolnirEventRaw = {
  type: 'handmove',
  srcEvent: new Event('handmove'),
  target: element,
  // ... additional hand tracking data
};

eventManager.emit(handEvent);
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)